### PR TITLE
fix: fix CI error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "lint": "yarn eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "build": "rimraf lib && tsc",
     "test": "jest --config jestconfig.json --unhandled-rejections=strict",
+    "coverage": "jest --config jestconfig.json --coverage",
     "prod": "webpack --config webpack.prod.js",
-    "dev": "webpack --config webpack.dev.js",
-    "coverage": "jest --coverage"
+    "dev": "webpack --config webpack.dev.js"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.11.0",
@@ -45,7 +45,7 @@
     "ts-jest": "^26.1.0",
     "ts-loader": "^8.0.2",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^3.9.6",
+    "typescript": "^4.8.3",
     "vue": "^3.0.7",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -19,8 +19,11 @@ describe('Enforcer plugin test', () => {
     let appRoot;
 
     const App = defineComponent({
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         inject: {
             authorizer: {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-ignore
                 from: AUTHORIZER_KEY,
             },
@@ -38,11 +41,13 @@ describe('Enforcer plugin test', () => {
     });
 
     it('Throw Error when authorizer is not provided.', () => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         expect(() => createApp().use(plugin)).toThrowError('Please provide an authorizer instance to plugin.');
     });
 
     it('Throw Error when fake authorizer is provided.', () => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         expect(() => createApp().use(plugin, {})).toThrowError('Please provide an authorizer instance to plugin.');
     });
@@ -90,22 +95,22 @@ describe('Enforcer plugin test', () => {
             vm = app.mount(appRoot);
         }
 
-        it("should have 'can' and 'cannot'", function() {
-            addCustomApp(['can','cannot'])
+        it("should have 'can' and 'cannot'", function () {
+            addCustomApp(['can', 'cannot']);
 
-            expect(vm.$can).toBeDefined()
-            expect(vm.$cannot).toBeDefined()
-            expect(vm.$authorizer).toBeDefined()
+            expect(vm.$can).toBeDefined();
+            expect(vm.$cannot).toBeDefined();
+            expect(vm.$authorizer).toBeDefined();
         });
 
-        it("should have 'can', 'cannot', 'canAll' and 'canAny'", function() {
-            addCustomApp(['can','cannot','canAll','canAny'])
+        it("should have 'can', 'cannot', 'canAll' and 'canAny'", function () {
+            addCustomApp(['can', 'cannot', 'canAll', 'canAny']);
 
-            expect(vm.$can).toBeDefined()
-            expect(vm.$cannot).toBeDefined()
-            expect(vm.$canAll).toBeDefined()
-            expect(vm.$canAny).toBeDefined()
-            expect(vm.$authorizer).toBeDefined()
+            expect(vm.$can).toBeDefined();
+            expect(vm.$cannot).toBeDefined();
+            expect(vm.$canAll).toBeDefined();
+            expect(vm.$canAny).toBeDefined();
+            expect(vm.$authorizer).toBeDefined();
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10129,10 +10129,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^3.9.6:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+typescript@^4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
+  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
 
 uglify-js@^3.1.4:
   version "3.17.1"


### PR DESCRIPTION
Fix: https://github.com/casbin-js/vue-authz/issues/11

The code uses `@ts-ignore` to skip type checking, but it is disabled by eslint in default. 
I'm not proficient in typescript and don't know how to not use this bad behavior on the original basis, so use `// eslint-disable-next-line @typescript-eslint/ban-ts-comment` to skip the lint in these lines.

I did not modify the eslint configuration file, that will not affect the code quality checks for the entire project.
 
![image](https://user-images.githubusercontent.com/41513919/192182840-2f6bcc92-2322-4c8f-aeda-e1eb7dc1a235.png)
