### PR TITLE
feat: support Vue2

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,16 @@
     "@babel/preset-env": "^7.11.0",
     "axios": "^0.21.1",
     "babel-loader": "^8.1.0",
-    "casbin.js": "^0.4.1"
+    "casbin.js": "^0.4.1",
+    "vue-demi": "^0.13.11"
+  },
+  "peerDependencies": {
+    "@vue/composition-api": "^1.3.0",
+    "vue": "^2.0.0 || >=3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@vue/composition-api": {
+      "optional": true
+    }
   }
 }

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,13 +1,13 @@
-import { App } from 'vue';
 import { Authorizer } from 'casbin.js';
 import { AUTHORIZER_KEY } from './useAuthorizer';
+import { isVue3 } from 'vue-demi';
 
 export interface CasbinPluginOptions {
     useGlobalProperties?: boolean;
     customProperties?: Array<string>;
 }
 
-const install = function (app: App, authorizer: Authorizer, options?: CasbinPluginOptions) {
+const install = function (app, authorizer: Authorizer, options?: CasbinPluginOptions) {
     const availableProperties = [
         'getPermission',
         'setPermission',
@@ -45,7 +45,8 @@ const install = function (app: App, authorizer: Authorizer, options?: CasbinPlug
         // }
 
         if (options.useGlobalProperties) {
-            app.config.globalProperties.$authorizer = authorizer;
+            const vueProperty = isVue3 ? app.config.globalProperties : app.prototype;
+            vueProperty.$authorizer = authorizer;
 
             if (options.customProperties) {
                 const targetProperties = availableProperties.filter((property: string) => {
@@ -58,7 +59,7 @@ const install = function (app: App, authorizer: Authorizer, options?: CasbinPlug
                     if (property) {
                         const propertyKey = `$${propertyStr}`
                         // app.config.globalProperties[propertyKey] = property;
-                        Object.defineProperty(app.config.globalProperties,propertyKey,{
+                        Object.defineProperty(vueProperty, propertyKey, {
                             enumerable: true,
                             configurable: true,
                             writable: true,
@@ -69,7 +70,7 @@ const install = function (app: App, authorizer: Authorizer, options?: CasbinPlug
                     }
                 });
             } else {
-                app.config.globalProperties.$can = authorizer.can;
+                vueProperty.$can = authorizer.can;
             }
         }
     }

--- a/src/useAuthorizer.ts
+++ b/src/useAuthorizer.ts
@@ -1,4 +1,4 @@
-import { inject, provide, InjectionKey } from 'vue';
+import { inject, provide, InjectionKey } from 'vue-demi';
 import { Authorizer } from 'casbin.js';
 
 const AUTHORIZER_KEY: InjectionKey<Authorizer> = Symbol('casbinjs_authorizer');

--- a/yarn.lock
+++ b/yarn.lock
@@ -10377,6 +10377,11 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
+vue-demi@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.11.tgz#7d90369bdae8974d87b1973564ad390182410d99"
+  integrity sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==
+
 vue@^3.0.7:
   version "3.2.39"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.39.tgz#de071c56c4c32c41cbd54e55f11404295c0dd62d"


### PR DESCRIPTION
Fix: https://github.com/casbin-js/vue-authz/issues/3

When I test my change in Vue2. It's seem work as same as Vue3.

**But there a error occur in `casbin.js`. I test in vue3 with `vue-authz(v0.0.1, v0.1.1)` and my change occur this error too, test follow the README.**

```js
// main.js
import { createApp } from 'vue'
import App from './App.vue'
import CasbinPlugin from 'vue-authz'

const permission = {
    "read": ['data1', 'data2'],
    "write": ['data1']
}

const casbinjs = require('casbin.js')
// Run casbin.js in manual mode, which requires you to set the permission manually.
const authorizer = new casbinjs.Authorizer("manual")

authorizer.setPermission(permission)

createApp(App).use(CasbinPlugin, authorizer, {
    useGlobalProperties: true
}).mount('#app')
```

```vue
<!-- App.vue -->
<template>
  <div id="app">
    <p v-if='$can("read","post")'>
      Post content.
    </p>
  </div>

</template>

<script>
export default {
  name: 'App',
}
</script>
```
![image](https://user-images.githubusercontent.com/41513919/192742104-997a78fd-3f07-484a-b560-afa1cd7945bb.png)

I roughly look at the code of `casbin.js`, but not sure this error. It's look like that's the `casbin.js` cause.









